### PR TITLE
Fix no-op goal for pose_delta_ori mode in DroidEndEffectorController

### DIFF
--- a/realm/robots/droid_ee_controller.py
+++ b/realm/robots/droid_ee_controller.py
@@ -265,7 +265,7 @@ class DroidEndEffectorController(LocomotionController, ManipulationController, G
             target_pos=pos_relative,
             target_quat=quat_relative,
             target_rpy=rpy_relative,
-            target_pos_relative=th.zeros(3, dtype=th.float32, device=pos_relative.device),
+            target_pos_relative=pos_relative.clone(),
             target_quat_relative=quat_relative,
             target_rpy_relative=th.zeros(3, dtype=th.float32, device=pos_relative.device),
             target_cartesian_pos_vel=th.zeros(3, dtype=th.float32, device=pos_relative.device),


### PR DESCRIPTION
## Summary

This PR fixes the no-op goal for `pose_delta_ori` mode in `DroidEndEffectorController`.

In `compute_no_op_goal()`, `target_pos` is set to the current relative EEF position, but `target_pos_relative` is set to zero:

```python
target_pos=pos_relative,
target_quat=quat_relative,
target_rpy=rpy_relative,
target_pos_relative=th.zeros(3, dtype=th.float32, device=pos_relative.device),
```

For `pose_delta_ori` mode, `compute_control()` reconstructs the Cartesian delta as:
```python
dpos = goal_dict["target_pos"] - goal_dict["target_pos_relative"]
```

Therefore, the previous no-op goal could produce a nonzero delta, `dpos = current_eef_pos - 0`, instead of a zero delta.

This PR changes `target_pos_relative` to the current relative EEF position:
```python
target_pos_relative=pos_relative.clone(),
```
so the no-op goal is consistent with zero position delta: `dpos = current_eef_pos - current_eef_pos = 0`.